### PR TITLE
Added functionality and fixes to b++ tags

### DIFF
--- a/Commands/b++.py
+++ b/Commands/b++.py
@@ -282,7 +282,7 @@ async def MAIN(message, args, level, perms, SERVER):
 
 	try:
 		await message.channel.send(
-		OUTPUT.replace("<@", "<\@").replace("\\\\", "\t\t").replace("\\", "").replace("\t\t", "\\")[:1950])
+		OUTPUT.replace("<@", "<\@").replace("\\\\", "\t\t").replace("\\", "").replace("\t\t", "\\").replace(u"\uF000","\n")[:1950])
 	except discord.errors.HTTPException:
 		pass
 	

--- a/Commands/b++.py
+++ b/Commands/b++.py
@@ -282,7 +282,7 @@ async def MAIN(message, args, level, perms, SERVER):
 
 	try:
 		await message.channel.send(
-		OUTPUT.replace("<@", "<\@").replace("\\\\", "\t\t").replace("\\", "").replace("\t\t", "\\").replace(u"\uF000","\n")[:1950])
+		OUTPUT.replace("<@", "<\@").replace("\\\\", "\t\t").replace("\\", "").replace("\t\t", "\\").replace(u"\uF000","\n",50)[:1950])
 	except discord.errors.HTTPException:
 		pass
 	

--- a/Config/_bpp_functions.py
+++ b/Config/_bpp_functions.py
@@ -14,6 +14,16 @@ def safe_exponent(a, b):
 		raise ValueError('Numbers are too large to exponentiate')
 	return a**b
 
+def safe_sort(a):
+	if len(a) > 1000:
+		raise ValueError('Iterable is too large to be sorted')
+	return sorted(a)
+
+def safe_desort(a):
+	if len(a) > 1000:
+		raise ValueError('Iterable is too large to be sorted')
+	return sorted(a, reverse=True)
+
 FUNCTIONS = {
 
 	# Basic operations
@@ -154,14 +164,14 @@ FUNCTIONS = {
 	},
 
 	"sort?": {
-		"MAIN": (lambda a: sorted(a)),
+		"MAIN": safe_sort,
 		"TYPES": {
 			"a": ["ARRAY NUMBER", "ARRAY STRING", "ARRAY BOOLEAN"]
 		}
 	},
 
 	"desort?": {
-		"MAIN": (lambda a: sorted(a, reverse=True)),
+		"MAIN": safe_desort,
 		"TYPES": {
 			"a": ["ARRAY NUMBER", "ARRAY STRING", "ARRAY BOOLEAN"]
 		}

--- a/Config/_bpp_parsing.py
+++ b/Config/_bpp_parsing.py
@@ -128,7 +128,8 @@ def parenthesis_parser(raw, VARIABLES, OUTPUT, var=False):
 					
 					# If it got here, that means the operation was successful and is not out{}
 					result = operation_info[1] # Define the result
-				
+					if type(result) == list: 
+						result = list_to_array(result) # Converts result to b++ array format if operation result is a list
 				elif r != 0: # If there was no matching operation, try to interpret it as a variable
 					# Do this if and only if r != 0, because if r == 0 the expression is outside parentheses, and
 					# variables are not meant to be called outside parentheses even when there's only a variable call


### PR DESCRIPTION
1. Safe versions of sorting functions for sort() and desort(), with a limit of iterables with at most 1000 items in them
2. Converting results of non out{} functions to b++ arrays so they can be chained properly, which should fix the bug in the attached image.
![Attachment](https://user-images.githubusercontent.com/31096837/92048847-c49fd180-ed56-11ea-9ab4-3c59dcdc77d3.png)
3. Added support for newline characters in b++ tags (as otherwise they just get filtered off somewhere), with a maximum of 50 replacements to prevent spam. You can use the character 0xF000 () (in the Unicode Private Use Area), and it will automatically be replaced to a newline character.
![Attachment2](https://user-images.githubusercontent.com/31096837/92049151-9bcc0c00-ed57-11ea-8de8-ea9918ec3bcc.png)

