### PR TITLE
Fix (hopefully) of escaped closing paren issue

### DIFF
--- a/Config/_bpp_parsing.py
+++ b/Config/_bpp_parsing.py
@@ -27,9 +27,7 @@ def parenthesis_parser(raw, VARIABLES, OUTPUT, var=False):
 				backslash = False # End the backslash
 			else: # If it's not backslashed, it's a level rise
 				current_level += 1 # Increase the current level
-
 				expression[current_var_index][1] += "{res}" # There's an operation to solve for this expression now
-
 				expression.append([current_level, "("]) # Add a new expression with the new level
 			continue
 		
@@ -41,10 +39,9 @@ def parenthesis_parser(raw, VARIABLES, OUTPUT, var=False):
 
 			elif current_level == 0: # Throw an error if there's an imbalance in the parenthesis level
 				raise SyntaxError("Unbackslashed closing parentheses without any opening parentheses.")
-			
-			# If it's not backslashed and it's valid...
-			expression[current_var_index][1] += ")" # Append it to the end of the current expression
-			current_level -= 1 # Go a level down
+				# If it's not backslashed and it's valid...
+				expression[current_var_index][1] += ")" # Append it to the end of the current expression
+				current_level -= 1 # Go a level down
 			continue
 		
 		if char == ";":


### PR DESCRIPTION
It seems part of the closing parenthesis code was one level down from where it should've been, which woude be inside the elif statement as the comment for that line implys.