### PR TITLE
Make raid protection work as intended

### DIFF
--- a/Events/raid_protection.py
+++ b/Events/raid_protection.py
@@ -65,7 +65,7 @@ class EVENT:
 		ping = sum(self.param["INFO"][message.author.id][1][-msg_ping:])
 
 		cause = "" # Determine the rule broken and specify it
-		if msg_1 >= self.param["MESSAGE_LIMIT"][0] or msg_2 >= self.param["MESSAGE_LIMIT"][0]:
+		if msg_1 >= self.param["MESSAGE_LIMIT"][0] or msg_2 >= self.param["MESSAGE_LIMIT"][1]:
 			cause = "sending messages too quickly"
 		if ping >= self.param["PING_LIMIT"]:
 			cause = "pinging too many people"


### PR DESCRIPTION
TBOTC is intended to mute non-members if they send 5 messages in 10 seconds, or if they send 10 messages in 30 seconds. However, a bug caused it to instead mute non-members if they send 5 messages in 30 seconds. This commit fixes this bug, making raid protection work as intended.