### PR TITLE
Finally fix B++ error messages

### DIFF
--- a/Config/_bppnew_functions.py
+++ b/Config/_bppnew_functions.py
@@ -16,7 +16,7 @@ def express_array(l):
 	return f'[ARRAY {str_form}]'
 
 def safe_cut(s):
-	return str(s)[:15] + ("..." if len(s) > 15 else "")
+	return str(s)[:15] + ("..." if len(str(s)) > 15 else "")
 
 def COMMENT(*a): return ""
 


### PR DESCRIPTION
This commit fixes the bug that was causing several B++ errors to become "object of type 'int' has no len()".