### PR TITLE
B*: Evaluate function names

### DIFF
--- a/Config/b_star_interpreter/expression.py
+++ b/Config/b_star_interpreter/expression.py
@@ -56,7 +56,7 @@ def Expression(block: Union[Tree, Token], codebase):
     # print(block, block.pretty())
     match block.data:
         case "function":
-            alias = block.children[0].children[0]
+            alias = Expression(block.children[0], globals.codebase)
 
             # this gets the argument values from the block
             # arguments = list(map(lambda x: Expression(x, codebase), block.children[1].children))


### PR DESCRIPTION
lets someone do 
```scala
[DEFINE e [choose "choose" "concat"]] [[VAR e] "a" "b" "c"]
```
which could either be
```scala
[CHOOSE "a" "b" "c"]
```
or 
```scala
[CONCAT "a" "b" "c"]
```